### PR TITLE
Renombrar la aplicación de "Guardian" a "Cryptshield"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,12 @@ share/python-wheels/
 *.egg
 MANIFEST
 debian/.debhelper
-debian/guardian
+debian/cryptshield
 debian/files
-debian/guardian.substvars
+debian/cryptshield.substvars
 debian/debhelper-build-stamp
-debian/guardian.postinst.debhelper
-debian/guardian.prerm.debhelper
+debian/cryptshield.postinst.debhelper
+debian/cryptshield.prerm.debhelper
 
 
 # PyInstaller

--- a/README.md
+++ b/README.md
@@ -18,33 +18,33 @@ This Python application allows you to securely encrypt files and directories usi
 
 ## **Usage**
 
-### **Running `guardian`**
+### **Running `cryptshield`**
 
 #### Basic syntax:
 
 ```sh
-guardian [COMMAND] [OPTION1] [OPTION2]
+cryptshield [COMMAND] [OPTION1] [OPTION2]
 ```
 
 #### Examples:
 
 ```sh
 # Encrypt a file
-guardian encrypt /path/to/file secret_key
+cryptshield encrypt /path/to/file secret_key
 
 # Decrypt a file
-guardian decrypt /path/to/file.encrypted secret_key
+cryptshield decrypt /path/to/file.encrypted secret_key
 
 # Encrypt a text
-guardian encrypt_text "Sample text" secret_key
+cryptshield encrypt_text "Sample text" secret_key
 "gAAAAABnsO0xV07ndDmt-fO..."
 
 # Decrypt a text
-guardian decrypt_text "gAAAAABnsO0xV07ndDmt-fO..." secret_key
+cryptshield decrypt_text "gAAAAABnsO0xV07ndDmt-fO..." secret_key
 "Sample text"
 
 # Secure file deletion
-guardian delete /path/to/file
+cryptshield delete /path/to/file
 ```
 
 ---
@@ -53,24 +53,24 @@ guardian delete /path/to/file
 
 ### Version 1.0.0
 
-You can download the latest release of the **Guardian** package as a `.deb` file from the following link:
+You can download the latest release of the **Cryptshield** package as a `.deb` file from the following link:
 
-[Download Guardian 1.0.0 (.deb)](https://github.com/wilmerm/guardian/releases/download/v1.0.0/guardian_1.0.0_all.deb)
+[Download Cryptshield 1.0.0 (.deb)](https://github.com/wilmerm/cryptshield/releases/download/v1.0.0/cryptshield_1.0.0_all.deb)
 
 ### Installation
 
 To install the package on your system, run the following command:
 
 ```bash
-wget https://github.com/wilmerm/guardian/releases/download/v1.0.0/guardian_1.0.0_all.deb
+wget https://github.com/wilmerm/cryptshield/releases/download/v1.0.0/cryptshield_1.0.0_all.deb
 
-sudo dpkg -i guardian_1.0.0_all.deb
+sudo dpkg -i cryptshield_1.0.0_all.deb
 ```
 
-After installation, you can run the `guardian` command by simply typing:
+After installation, you can run the `cryptshield` command by simply typing:
 
 ```bash
-guardian encrypt [FILE] [KEY]
+cryptshield encrypt [FILE] [KEY]
 ```
 
 If you encounter any issues with dependencies, you can resolve them using:
@@ -95,7 +95,7 @@ If you plan to use **secure deletion**, make sure you have administrator (`sudo`
 
 ### Installation and `.deb` Package Creation
 
-Follow these steps to create and install the `.deb` package for *Guardian*:
+Follow these steps to create and install the `.deb` package for *Cryptshield*:
 
 #### 1. Build the Package
 Run:
@@ -105,8 +105,8 @@ dpkg-buildpackage -us -uc
 
 #### 2. Install and Test
 ```bash
-sudo dpkg -i ../guardian_<version>_all.deb
-guardian
+sudo dpkg -i ../cryptshield_<version>_all.deb
+cryptshield
 ```
 
 If there are dependency issues, fix them with:

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -1,12 +1,12 @@
 
 rm -rf .pybuild
 rm -rf build
-rm -rf guardian.egg-info
+rm -rf cryptshield.egg-info
 rm -rf debian/.debhelper
-rm -rf debian/guardian
-rm -f debian/guardian.debhelper.log
-rm -f debian/guardian.substvars
+rm -rf debian/cryptshield
+rm -f debian/cryptshield.debhelper.log
+rm -f debian/cryptshield.substvars
 rm -f debian/files
 rm -f debian/debhelper-build-stamp
-rm -r debian/guardian.postinst.debhelper
-rm -r debian/guardian.prerm.debhelper
+rm -r debian/cryptshield.postinst.debhelper
+rm -r debian/cryptshield.prerm.debhelper

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-guardian (1.0.0) unstable; urgency=medium
+cryptshield (1.0.0) unstable; urgency=medium
 
   * First package version
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: guardian
+Source: cryptshield
 Maintainer: Wilmer Martinez <info@wilmermartinez.dev>
 Section: utils
 Priority: optional
@@ -6,7 +6,7 @@ Standards-Version: 4.5.0
 Build-Depends: debhelper-compat (= 13), dh-python, python3, python3-setuptools
 
 
-Package: guardian
+Package: cryptshield
 Architecture: all
 Depends: python3, python3-requests, ${misc:Depends}, ${python3:Depends}
-Description: Guardian - Secure Encryption and Deletion Application
+Description: Cryptshield - Secure Encryption and Deletion Application

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: guardian
-Source: https://github.com/wilmerm/guardian
+Upstream-Name: cryptshield
+Source: https://github.com/wilmerm/cryptshield
 
 Files: *
 Copyright: 2025 Wilmer Martinez <info@wilmermartinez.dev>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    name="guardian",
+    name="cryptshield",
     version="1.0",
     packages=["src"],
     install_requires=[
@@ -9,7 +9,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "guardian=src.guardian:main",
+            "cryptshield=src.cryptshield:main",
         ]
     },
 )

--- a/src/cryptshield.py
+++ b/src/cryptshield.py
@@ -14,7 +14,7 @@ ENCRYPTED = 'encrypted'
 ZIPENCRYPTED = 'zipencrypted'
 
 
-class GuardianError(Exception):
+class CryptshieldError(Exception):
     pass
 
 
@@ -109,7 +109,7 @@ def encrypt(path: str, key: str, delete: bool = True):
             secure_delete(path)
 
     else:
-        raise GuardianError(f'"{path}" is not a valid file or directory.')
+        raise CryptshieldError(f'"{path}" is not a valid file or directory.')
 
 
 def decrypt(path: str, key: str, delete: bool = True):
@@ -173,7 +173,7 @@ def decrypt(path: str, key: str, delete: bool = True):
                     secure_delete(path)
 
     else:
-        raise GuardianError(f'"{path}" is not valid file or directory.')
+        raise CryptshieldError(f'"{path}" is not valid file or directory.')
 
 
 def encrypt_text(text: str | bytes, key: str = None) -> bytes:
@@ -221,7 +221,7 @@ def decrypt_text(encrypted_text: str, key: str, to_str: bool = True) -> str | by
 
     This function uses the Fernet symmetric encryption algorithm to decrypt the
     provided text. The key must match the one used for encryption, otherwise
-    a GuardianError will be raised.
+    a CryptshieldError will be raised.
 
     Example:
         ```
@@ -240,7 +240,7 @@ def decrypt_text(encrypted_text: str, key: str, to_str: bool = True) -> str | by
     try:
         decrypted_bytes = fernet.decrypt(encrypted_text)
     except InvalidToken as e:
-        raise GuardianError(f'Invalid key: {e}')
+        raise CryptshieldError(f'Invalid key: {e}')
 
     if to_str:
         return decrypted_bytes.decode('utf-8', errors='ignore')
@@ -388,7 +388,7 @@ def main():
         result = command(*options)
         if result is not None:
             print(result)
-    except GuardianError as e:
+    except CryptshieldError as e:
         print(f'Error executing command "{command_name}": {str(e)}')
         sys.exit(1)
 

--- a/src/cryptshield.sh
+++ b/src/cryptshield.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTHONPATH=$(dirname $(dirname $(realpath $0)))/src python3 -m guardian "$@"
+PYTHONPATH=$(dirname $(dirname $(realpath $0)))/src python3 -m cryptshield "$@"
 
 # Validate if at least one argument is provided
 if [ -z "$1" ]; then
@@ -13,4 +13,4 @@ command_name="$1"
 option1="${2:-}"
 option2="${3:-}"
 
-python3 guardian.py "$command_name" "$option1" "$option2"
+python3 cryptshield.py "$command_name" "$option1" "$option2"


### PR DESCRIPTION
This pull request includes a comprehensive rebranding of the application from `guardian` to `cryptshield`. The changes span across multiple files, including the README, shell scripts, Python scripts, and Debian packaging files. The most important changes are summarized below:

### Rebranding in Documentation and Usage Instructions:
* Updated the application name from `guardian` to `cryptshield` in the `README.md` file, including command examples and installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R73) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R98) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R109)

### Rebranding in Build and Packaging Files:
* Changed the package name from `guardian` to `cryptshield` in `debian/control`, `debian/changelog`, and `debian/copyright`. [[1]](diffhunk://#diff-93467241211d3f9d253fb8ad341738fbda5e5d3ade4721326f2bba82525fbaeeL1-R1) [[2]](diffhunk://#diff-2a13f1344504379e877324d3a0375adcbcb4cb27d7e575ad8f4618a52d6a00e0L1-R12) [[3]](diffhunk://#diff-248a3ad2376574c96e7b8fc79764c5a217d4d41c8bf8679bcca1c3b7b87f8ff2L2-R3)
* Updated the `setup.py` file to reflect the new package name `cryptshield`.

### Rebranding in Source Code:
* Renamed the main Python script from `guardian.py` to `cryptshield.py` and updated class and error names accordingly. [[1]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L17-R17) [[2]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L112-R112) [[3]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L176-R176) [[4]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L224-R224) [[5]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L243-R243) [[6]](diffhunk://#diff-6945cbba8b4502d83cca3034d2c858b78b97c229b39d3128270aaad05fdc9914L391-R391)
* Renamed the shell script from `guardian.sh` to `cryptshield.sh` and updated the script content to call the new Python module name. [[1]](diffhunk://#diff-957aa6561062fc97a158600060229962bf348656518ef6f16e6f25a89fdde9e1L3-R3) [[2]](diffhunk://#diff-957aa6561062fc97a158600060229962bf348656518ef6f16e6f25a89fdde9e1L16-R16)

### Cleanup Script Update:
* Modified `cleanbuild.sh` to remove old `guardian` build artifacts and replace them with `cryptshield` artifacts.